### PR TITLE
Allow PHP 8.1 and Laravel 9 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require":{
         "google/cloud-functions-framework":"^1.1",
         "guzzlehttp/guzzle": "^7.4",
-        "laravel/framework":"^8.0",
+        "laravel/framework":"^9.0|^8.0",
         "php":"^7.4"
     },
     "autoload":{

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,8 @@
     ],
     "require":{
         "google/cloud-functions-framework":"^1.1",
-        "guzzlehttp/guzzle": "^7.4",
         "laravel/framework":"^9.0|^8.0",
-        "php":"^7.4"
+        "php":"^8.1|^8.0|^7.4"
     },
     "autoload":{
        "psr-4":{


### PR DESCRIPTION
Also removed Guzzle because I didn't see it being used by the package.