### PR TITLE
Change asset publishing tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ Basic Configuration for running Laravel as a native php Google Cloud Function
     :~/code/laravel-gcf$ composer require rverrips/laravel-google-cloud-function-config
     ```
 
-Note that the package will publish the assets (index.php and .gcloudingnore) into root of project
+4. Publish the assets (new `index.php` + `.gcloudignore`)
+
+    ```bash
+    :~/code/laravel-gcf$ php artisan vendor:publish tag=laravel-google-cloud-function-config
+    ```
 
 # Running Locally
 

--- a/src/GoogleCloudFunctionConfigServiceProvider.php
+++ b/src/GoogleCloudFunctionConfigServiceProvider.php
@@ -95,6 +95,6 @@ class GoogleCloudFunctionConfigServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../index.php' => $this->app->basePath('index.php'),
             __DIR__ . '/../.gcloudignore' => $this->app->basePath('.gcloudignore'),
-        ], 'laravel-assets');
+        ], 'laravel-google-cloud-function-config');
     }
 }


### PR DESCRIPTION
I noticed each time I ran `composer update` my changes to `.gcloudignore` were being overwritten because composer was running `vendor:publish --tag=laravel-assets`. I think `laravel-assets` may be the default tag/group for more Laravel-specific assets.